### PR TITLE
DEV-009 Removed _v and normalised _id to id on response object

### DIFF
--- a/server/models/Mentor.js
+++ b/server/models/Mentor.js
@@ -16,4 +16,15 @@ const MentorSchema = new mongoose.Schema({
   },
 })
 
+
+MentorSchema.set('toJSON', {
+  transform: (document, returnedObject) => {
+    returnedObject.id = returnedObject._id.toString()
+    delete returnedObject._id
+    delete returnedObject.__v
+  }
+})
+
+
+
 module.exports = mongoose.model('Mentor', MentorSchema)


### PR DESCRIPTION
## Rationale
This commit changes the mongoose schema of Mentors so that the _v is removed and _id is changed to id when GET requests are made. 
This simplifies the logic that fetches items from the database, so tat we don't need to change these values manually in the code. 
This can be reused in all schemas to get similar responses

## Advice for Reviewers & Testing Notes

- Clone and  make a get request to see _v removed from the response and get id instead of _id

## Screenshots:

- Old response from GET request:
![IMG20200404211509](https://user-images.githubusercontent.com/46081079/78424895-5332f880-76bc-11ea-8ca0-3a0a270fcb3a.jpg)

-New response from GET request:

![IMG20200404211538](https://user-images.githubusercontent.com/46081079/78424955-bd4b9d80-76bc-11ea-8962-529e554414f3.jpg)



## Task Name

-DEV-009 Removing the _v and normalise the _id on response object


## Linting Checklist
The following is a list of linting rules that ESLint is not currently linting for. Please make sure your code conforms to this list. Examples/definitions of the rules can be found [here](https://hireup.atlassian.net/wiki/pages/viewpageattachments.action?pageId=618037301&metadataLink=true&preview=/618037301/618168365/PR_Checklist.pdf)
- [x] No commented code
- [x] Code Formatted nicely (Prettier)
- [x] PR your own code before you assign reviewers

