### PR TITLE
DEV-013 Adding error handling for Malformatted ID

### DIFF
--- a/server/controller/MentorController.js
+++ b/server/controller/MentorController.js
@@ -1,6 +1,6 @@
 const catchAsync = require('../utils/catchAsync')
 const Mentor = require('../model/Mentor')
-const { NotFoundError } = require('../errors')
+const { NotFoundError, MalformattedIdError } = require('../errors')
 const constants = require('../constant')
 
 
@@ -28,35 +28,53 @@ const MentorController = () => {
   })
 
   const getMentor = catchAsync(async (req, res, next) => {
-    const mentor = await Mentor.findById(req.params.mentorId)
 
-    if (!mentor) {
-      return next(NotFoundError('No mentor with this ID'))
-    }
+    try{
+      const mentor = await Mentor.findById(req.params.mentorId)
 
-    res.status(constants.httpStatus.ok).json({
-      status: constants.result.success,
-      data: {
-        mentor,
-      },
-    })
+      if (!mentor) {
+        return next(NotFoundError('No mentor with this ID'))
+      }
+
+      res.status(constants.httpStatus.ok).json({
+        status: constants.result.success,
+        data: {
+          mentor,
+        },
+      })
+   }
+    catch{
+      return next(MalformattedIdError('Malformatted ID'))
+
+   }
+ 
+
+ 
   })
 
   const updateMentor = catchAsync(async (req, res, next) => {
-    const mentor = await Mentor.findByIdAndUpdate(
-      req.params.mentorId,
-      req.body,
-      { new: true }
-    )
-    if (!mentor) {
-      return next(NotFoundError('No mentor with this ID'))
+
+    try{
+      const mentor = await Mentor.findByIdAndUpdate(
+        req.params.mentorId,
+        req.body,
+        { new: true }
+      )
+      if (!mentor) {
+        return next(NotFoundError('No mentor with this ID'))
+      }
+      res.status(constants.httpStatus.ok).json({
+        status: constants.result.success,
+        data: {
+          mentor,
+        },
+      })
+
     }
-    res.status(constants.httpStatus.ok).json({
-      status: constants.result.success,
-      data: {
-        mentor,
-      },
-    })
+    catch{
+      return next(MalformattedIdError('Malformatted ID'))
+    }
+
   })
 
   const deleteMentor = catchAsync(async (req, res, next) => {

--- a/server/errors/MalformattedIdError.js
+++ b/server/errors/MalformattedIdError.js
@@ -1,0 +1,12 @@
+const MalformattedIdError = function MalformattedIdError(message) {
+    if (!new.target) {
+      return new MalformattedIdError(message)
+    }
+  
+    this.name = this.constructor.name
+    this.message = message
+    Error.captureStackTrace(this, this.constructor)
+  }
+  
+  module.exports = MalformattedIdError
+  require('util').inherits(module.exports, Error) 

--- a/server/errors/index.js
+++ b/server/errors/index.js
@@ -6,5 +6,7 @@ const UnauthorizedError = require('./UnauthorizedError')
 
 const ForbiddenError = require('./ForbiddenError')
 
+const MalformattedIdError = require('./MalformattedIdError')
 
-module.exports = { NotFoundError, PreconditionError, UnauthorizedError, ForbiddenError }
+
+module.exports = { NotFoundError, PreconditionError, UnauthorizedError, ForbiddenError, MalformattedIdError }

--- a/server/middleware/ErrorHandler.js
+++ b/server/middleware/ErrorHandler.js
@@ -1,4 +1,4 @@
-const { NotFoundError, PreconditionError,UnauthorizedError, ForbiddenError } = require('../errors')
+const { NotFoundError, PreconditionError,UnauthorizedError, ForbiddenError, MalformattedIdError } = require('../errors')
 const constants = require('../constant')
 
 const ErrorHandler = () => (error, req, res, next) => {
@@ -17,6 +17,8 @@ const ErrorHandler = () => (error, req, res, next) => {
       return buildErrorItem(error, constants.httpStatus.unauthorized)
     case ForbiddenError:
       return buildErrorItem(error, constants.httpStatus.forbidden)
+    case MalformattedIdError:
+      return buildErrorItem(error, constants.httpStatus.badRequest)
     default:
       return buildErrorItem(error, constants.httpStatus.internalServerError)
   }


### PR DESCRIPTION
## Rationale
This commit adds an error handler for requests to the database that have malformatted ID.

## Advice for Reviewers & Testing Notes

- In either GET or PUT mentors by ID, try adding or removing a letter from the id so that the format of ID doesn't match what the MongoDB expects for ID. 

## Screenshots:

- Before implementing custom error handler for MalformattedID
![11111](https://user-images.githubusercontent.com/46081079/78875181-d96e8680-7a90-11ea-9a74-d4504723060f.png)

-After:
![2222](https://user-images.githubusercontent.com/46081079/78875199-de333a80-7a90-11ea-93ec-8596fdbcf747.png)

## Task Name

- DEV-013 GET/PUT Requests Error Fix


## Linting Checklist
The following is a list of linting rules that ESLint is not currently linting for. Please make sure your code conforms to this list. Examples/definitions of the rules can be found [here](https://hireup.atlassian.net/wiki/pages/viewpageattachments.action?pageId=618037301&metadataLink=true&preview=/618037301/618168365/PR_Checklist.pdf)
- [ ] No commented code
- [ ] Code Formatted nicely (Prettier)
- [ ] PR your own code before you assign reviewers

