### PR TITLE
I44 Codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo for review, unless a later match takes precedence, 
+# when someone opens a pull request.
+* @QjStout


### PR DESCRIPTION
## Rationale

Assigning Qj as the codeowner for this repo so that every time someones open a PR (Pull Request), it would automatically add Qj as a reviewer.

## Advice for Reviewers & Testing Notes

- Open up a PR
- Qj should now be automatically added to the reviewer list as a codeowner

## Screenshots:

- N/A

## Task Name

- Auto-assign @QjStout as a reviewer on all PRs #44

## Linting Checklist
- [x] Code Formatted nicely (Prettier)
- [x] PR your own code before you assign reviewers
